### PR TITLE
arrow labels adaptive to mode 

### DIFF
--- a/klimaland-app/src/components/LayoutManager.js
+++ b/klimaland-app/src/components/LayoutManager.js
@@ -168,7 +168,13 @@ export default class LayoutManager extends Component {
     const rightCard = (this.state.activeCard + 1) % this.state.cardSelection.length;
     let sectionLabel = this.state.cardSelection[rightCard].section.label;
     if (sectionLabel === 'Landwirtschaft') sectionLabel = 'Landw.';
-    const rightCardPreview = sectionLabel + ':\n' + this.state.cardSelection[rightCard].lk.label;
+    let rightCardPreview = '';
+    if (this.state.mode === 'comparison') {
+      rightCardPreview = this.state.cardSelection[rightCard].lk.label;
+    }
+    if (this.state.mode === 'lk') {
+      rightCardPreview = sectionLabel;
+    }
     this.setState({ previewRightCard: rightCardPreview });
     //if going back
 
@@ -177,7 +183,14 @@ export default class LayoutManager extends Component {
     if (leftCard < 0) leftCard = this.state.cardSelection.length - 1;
     sectionLabel = this.state.cardSelection[leftCard].section.label;
     if (sectionLabel === 'Landwirtschaft') sectionLabel = 'Landw.';
-    const leftCardPreview = sectionLabel + '\n' + this.state.cardSelection[leftCard].lk.label;
+    let leftCardPreview = '';
+    if (this.state.mode === 'comparison') {
+      leftCardPreview = this.state.cardSelection[leftCard].lk.label;
+    }
+    if (this.state.mode === 'lk') {
+      leftCardPreview = sectionLabel;
+    }
+
     this.setState({ previewLeftCard: leftCardPreview });
   }
 

--- a/klimaland-app/src/styles/main.scss
+++ b/klimaland-app/src/styles/main.scss
@@ -180,7 +180,7 @@ code {
       display: flex;
       flex-direction: row;
       justify-content: flex-start;
-      z-index:2;
+      z-index: 2;
 
       .selector {
         width: 30%;
@@ -212,14 +212,15 @@ code {
           }
         }
 
-        .css-1s2u09g-control,.css-1pahdxg-control{
+        .css-1s2u09g-control,
+        .css-1pahdxg-control {
           border: 1px solid $pale-olive;
           border-radius: 0px;
           box-shadow: map-get($map: $boxshadow, $key: default);
-      
+
           &:hover {
-              transition: 0.2s;
-              box-shadow: map-get($map: $boxshadow, $key: hover);
+            transition: 0.2s;
+            box-shadow: map-get($map: $boxshadow, $key: hover);
           }
         }
       }
@@ -264,9 +265,9 @@ code {
             margin-top: 0.5rem;
             opacity: 0;
             transition: all 0.5s;
-            font-size: 10px;
+            font-size: 12px;
             width: 80%;
-            overflow: hidden;
+            overflow: visible;
             text-overflow: ellipsis;
           }
         }


### PR DESCRIPTION
close #468

I don't even now if we want this, I just tried it out.
the labels above the arrow are now either sections (in landkreis mode) or locations (in comparison mode) of the left and right card