### PR TITLE
Safari font weight

### DIFF
--- a/klimaland-app/src/styles/_card.scss
+++ b/klimaland-app/src/styles/_card.scss
@@ -383,6 +383,7 @@
           // margin-left: 0.5rem;
           display: inline-flex;
           h4 {
+            font-weight: bold;
             margin: 0;
             margin-top: 0.2rem;
           }

--- a/klimaland-app/src/styles/_card.scss
+++ b/klimaland-app/src/styles/_card.scss
@@ -439,6 +439,9 @@
 
             text {
               font-family: 'Chivo';
+              fill: $default-text;
+              font-weight: normal;
+              font-size: 1em;
             }
 
             .mobile-toggle-label {

--- a/klimaland-app/src/styles/_charts.scss
+++ b/klimaland-app/src/styles/_charts.scss
@@ -692,7 +692,6 @@ $gas: lighten($dark-pink, 5%);
               .legend-element {
                 cursor: pointer;
                 display: flex;
-                margin-left: 1rem;
 
                 &:hover {
                   p {
@@ -720,7 +719,6 @@ $gas: lighten($dark-pink, 5%);
         }
 
         .caption {
-          margin-left: 1rem;
           span {
             color: $dark-blue;
           }
@@ -1130,7 +1128,6 @@ $gas: lighten($dark-pink, 5%);
         }
 
         .legend {
-          margin-left: 1rem;
           margin-top: 2rem;
           svg {
             font-size: 12px;
@@ -1138,8 +1135,6 @@ $gas: lighten($dark-pink, 5%);
         }
 
         .caption {
-          margin-left: 1rem;
-
           span {
             color: $dark-blue;
           }

--- a/klimaland-app/src/styles/_charts.scss
+++ b/klimaland-app/src/styles/_charts.scss
@@ -696,7 +696,7 @@ $gas: lighten($dark-pink, 5%);
 
                 &:hover {
                   p {
-                    font-weight: 600;
+                    font-weight: bold;
                   }
                 }
 
@@ -711,7 +711,7 @@ $gas: lighten($dark-pink, 5%);
                   margin-left: 5px;
 
                   &.selected {
-                    font-weight: 800;
+                    font-weight: bold;
                   }
                 }
               }

--- a/klimaland-app/src/styles/_config.scss
+++ b/klimaland-app/src/styles/_config.scss
@@ -13,6 +13,16 @@
 @font-face {
   font-family: Chivo;
   src: url('../fonts/chivo/Chivo-Light.otf');
+  font-weight: light;
+}
+@font-face {
+  font-family: Chivo;
+  src: url('../fonts/chivo/chivo_regular.ttf');
+}
+@font-face {
+  font-family: Chivo;
+  src: url('../fonts/chivo/chivo_bold.ttf');
+  font-weight: bold;
 }
 
 @import url('https://fonts.googleapis.com/css2?family=Vampiro+One&display=swap');

--- a/klimaland-app/src/styles/_config.scss
+++ b/klimaland-app/src/styles/_config.scss
@@ -260,13 +260,13 @@ text {
   .description {
     width: 35%;
     height: 100%;
-    margin-left: 0.5rem;
+    margin-left: 1rem;
 
     .title {
       border-bottom: 1px solid $default-text;
 
       h4 {
-        padding: 0rem 0.5rem 0rem 1rem;
+        padding: 0rem 0.5rem;
       }
 
       span {
@@ -275,12 +275,14 @@ text {
     }
 
     .caption {
+      margin-left: 0.5rem;
       p {
         font-size: 12px;
       }
     }
 
     .legend {
+      margin-left: 0.5rem;
       img {
         width: 100%;
         height: auto;

--- a/klimaland-app/src/styles/main.scss
+++ b/klimaland-app/src/styles/main.scss
@@ -82,7 +82,6 @@ h3 {
 
 h4 {
   @include title;
-  font-weight: 600;
 }
 
 ul {

--- a/klimaland-app/src/styles/main.scss
+++ b/klimaland-app/src/styles/main.scss
@@ -70,18 +70,22 @@ button,
 h1 {
   @include title;
   margin-top: 0;
+  font-weight: normal;
 }
 
 h2 {
   @include title;
+  font-weight: normal;
 }
 
 h3 {
   @include title;
+  font-weight: normal;
 }
 
 h4 {
   @include title;
+  font-weight: normal;
 }
 
 ul {

--- a/klimaland-app/src/styles/main.scss
+++ b/klimaland-app/src/styles/main.scss
@@ -73,17 +73,11 @@ h1 {
   font-weight: normal;
 }
 
-h2 {
-  @include title;
-  font-weight: normal;
-}
-
-h3 {
-  @include title;
-  font-weight: normal;
-}
-
-h4 {
+h2,
+h3,
+h4,
+h5,
+h6 {
   @include title;
   font-weight: normal;
 }

--- a/klimaland-app/src/styles/main.scss
+++ b/klimaland-app/src/styles/main.scss
@@ -82,6 +82,7 @@ h3 {
 
 h4 {
   @include title;
+  font-weight: 600;
 }
 
 ul {


### PR DESCRIPTION
we only imported the "light" font of Chivo before and every bold was just a faux rendering of the light font. That is how the weird look in safari vs. firefox happened.

now: all font weights are imported 

but: we need to rethink where we want bold and where we want regular

close #466 