### PR TITLE
location name in label is bold, in dust-blue

### DIFF
--- a/klimaland-app/src/components/side-elements/vis/AbBiotonneWeight.js
+++ b/klimaland-app/src/components/side-elements/vis/AbBiotonneWeight.js
@@ -233,9 +233,9 @@ const Waste = ({ currentData, locationLabel, isThumbnail, footnote, cardNumber }
       <div className="description">
         <div className="title">
           <h4>
-            Im Jahr <span>{lastYear}</span> wurden in <span>{locationLabel}</span> pro Kopf{' '}
-            <span>{formatNumber(lastValue)} kg</span> organische Abfälle korrekt in der Biotonne
-            oder als Gartenabfälle entsorgt und damit CO<sub>2</sub>-Emissionen verringert.{' '}
+            Im Jahr {lastYear} wurden in <span className="locationLabel">{locationLabel}</span> pro
+            Kopf <span>{formatNumber(lastValue)} kg</span> organische Abfälle korrekt in der
+            Biotonne oder als Gartenabfälle entsorgt und damit CO<sub>2</sub>-Emissionen verringert.{' '}
             {footnote}
             {footnote !== '' && '.'}
           </h4>

--- a/klimaland-app/src/components/side-elements/vis/EnIndustry.js
+++ b/klimaland-app/src/components/side-elements/vis/EnIndustry.js
@@ -298,8 +298,9 @@ const EnIndustry = ({
                         />
                         {label.value !== 0 && (
                           <g
-                            className={`interactive-labels ${activeLabel === l ? 'active-label' : ''
-                              }`}
+                            className={`interactive-labels ${
+                              activeLabel === l ? 'active-label' : ''
+                            }`}
                             transform={`translate(${label.xValue}, ${label.yValue})`}
                           >
                             <foreignObject
@@ -328,9 +329,11 @@ const EnIndustry = ({
         <div className="title">
           <h4>
             Der Energieverbrauch in der Industrie in{' '}
-            <span>{showBundeslandForLK ? locationLabel[1] : locationLabel[0]}</span> basiert im Jahr{' '}
-            <span>{lastYear}</span> zu{' '}
-            <span className="second-value"> {formatNumber(percRenewables)}</span> % auf{' '}
+            <span className="locationLabel">
+              {showBundeslandForLK ? locationLabel[1] : locationLabel[0]}
+            </span>{' '}
+            basiert im Jahr {lastYear} zu{' '}
+            <span className="second-value"> {formatNumber(percRenewables)} %</span> auf{' '}
             <span className="second-value"> erneuerbaren Energien</span>.{' '}
             {showBundeslandForLK && secretFootnote}
             {footnote}

--- a/klimaland-app/src/components/side-elements/vis/EnPrimaryEnergy.js
+++ b/klimaland-app/src/components/side-elements/vis/EnPrimaryEnergy.js
@@ -314,8 +314,9 @@ const Energy = ({
                         />
                         {label.value !== 0 && (
                           <g
-                            className={`interactive-labels ${activeLabel === l ? 'active-label' : ''
-                              }`}
+                            className={`interactive-labels ${
+                              activeLabel === l ? 'active-label' : ''
+                            }`}
                             transform={`translate(${label.xValue}, ${label.yValue})`}
                           >
                             <foreignObject
@@ -343,9 +344,9 @@ const Energy = ({
       <div className="description">
         <div className="title">
           <h4>
-            Der Energieverbrauch in <span>{locationLabel}</span> basiert im Jahr{' '}
-            <span>{lastYear}</span> zu{' '}
-            <span className="second-value"> {formatNumber(percRenewables)}</span> % auf{' '}
+            Der Energieverbrauch in <span className="locationLabel">{locationLabel}</span> basiert
+            im Jahr {lastYear} zu{' '}
+            <span className="second-value"> {formatNumber(percRenewables)} %</span> auf
             <span className="second-value"> erneuerbaren Energien</span>.
           </h4>
         </div>

--- a/klimaland-app/src/components/side-elements/vis/GeAvgHeating.js
+++ b/klimaland-app/src/components/side-elements/vis/GeAvgHeating.js
@@ -169,8 +169,9 @@ const GeAvgHEating = ({
                 return (
                   <g
                     key={b}
-                    className={`single-bar ${higlightedBar === b || higlightedBar === '' ? 'in-focus' : 'no-focus'
-                      }`}
+                    className={`single-bar ${
+                      higlightedBar === b || higlightedBar === '' ? 'in-focus' : 'no-focus'
+                    }`}
                     transform={`translate(${bar.year}, 0)`}
                     onMouseEnter={() => switchHighlightedBar(b)}
                     onMouseLeave={() => switchHighlightedBar('')}
@@ -245,7 +246,8 @@ const GeAvgHEating = ({
       <div className="description">
         <div className="title">
           <h4>
-            Wie hoch ist der Energieverbrauch beim Heizen in <span>{locationLabel}</span>?
+            Wie hoch ist der Energieverbrauch beim Heizen in{' '}
+            <span className="locationLabel">{locationLabel}</span>?
           </h4>
         </div>
       </div>

--- a/klimaland-app/src/components/side-elements/vis/GeNewBuildings.js
+++ b/klimaland-app/src/components/side-elements/vis/GeNewBuildings.js
@@ -225,7 +225,7 @@ const Buildings = ({
       <div className="description">
         <div className="title" style={{ display: isMobile ? 'block' : 'none' }}>
           <h4>
-            Wie wird in Neubauten in <span>{locationLabel}</span> geheizt?
+            Wie wird in Neubauten in <span className="locationLabel">{locationLabel}</span> geheizt?
           </h4>
         </div>
         <div className="title" style={{ display: isMobile ? 'none' : 'block' }}>
@@ -233,8 +233,8 @@ const Buildings = ({
         </div>
         <div className={`${cleanKlassString(currentId).toLowerCase()} caption`}>
           <p>
-            Durchschnittlich werden in <span>{locationLabel}</span> pro Jahr{' '}
-            <span>{formatNumber(numberOfBuildings)}</span> neue Wohnungen oder Häuser
+            Durchschnittlich werden in <span className="locationLabel">{locationLabel}</span> pro
+            Jahr <span>{formatNumber(numberOfBuildings)}</span> neue Wohnungen oder Häuser
             fertiggestellt. Davon werden{' '}
             <span className="energy-number">{formatNumber(selectedEnergy)} %</span> mit{' '}
             <span className="energy-number">{getDescriptionName(firstToUppercase(currentId))}</span>{' '}

--- a/klimaland-app/src/components/side-elements/vis/LaAnimalCount.js
+++ b/klimaland-app/src/components/side-elements/vis/LaAnimalCount.js
@@ -305,8 +305,9 @@ const Land = ({ currentData, locationLabel, isThumbnail, cardNumber }) => {
       <div className="description">
         <div className="title">
           <h4>
-            So hat sich die Anzahl an Rindern, Schweinen und Schafen in <span>{locationLabel}</span>{' '}
-            über die Jahre {firstYear} bis {lastYear} entwickelt.
+            So hat sich die Anzahl an Rindern, Schweinen und Schafen in{' '}
+            <span className="locationLabel">{locationLabel}</span> über die Jahre {firstYear} bis{' '}
+            {lastYear} entwickelt.
           </h4>
         </div>
       </div>

--- a/klimaland-app/src/components/side-elements/vis/LaAnimalDensity.js
+++ b/klimaland-app/src/components/side-elements/vis/LaAnimalDensity.js
@@ -113,7 +113,8 @@ const LandDenisty = ({ currentData, locationLabel, cardNumber }) => {
       <div className="description">
         <div className="title">
           <h4>
-            Wie viele Tiere pro Fläche leben im Durchschnitt in <span>{locationLabel}</span>?
+            Wie viele Tiere pro Fläche leben im Durchschnitt in{' '}
+            <span className="locationLabel">{locationLabel}</span>?
           </h4>
         </div>
         <div className="caption">

--- a/klimaland-app/src/components/side-elements/vis/MoCarDensity.js
+++ b/klimaland-app/src/components/side-elements/vis/MoCarDensity.js
@@ -114,7 +114,7 @@ const MoCarDensity = ({
       <div className="description">
         <div className="title">
           <h4>
-            In <span>{locationLabel}</span> kommen auf 100 Einwohner*innen{' '}
+            In <span className="locationLabel">{locationLabel}</span> kommen auf 100 Einwohner*innen{' '}
             <span className="first-value">{totalCars}</span> Autos. Davon sind{' '}
             <span className="second-value">{hybridCars}</span> mit Hybrid- oder Elektroantrieb.
           </h4>

--- a/klimaland-app/src/components/side-elements/vis/MoModalSplit.js
+++ b/klimaland-app/src/components/side-elements/vis/MoModalSplit.js
@@ -286,7 +286,8 @@ const MoModalSplit = ({
       <div className="description">
         <div className="title">
           <h4>
-            Mit was und wie weit fahren Menschen in <span>{locationLabel}</span> zur Arbeit?
+            Mit was und wie weit fahren Menschen in{' '}
+            <span className="locationLabel">{locationLabel}</span> zur Arbeit?
           </h4>
         </div>
       </div>

--- a/klimaland-app/src/styles/_config.scss
+++ b/klimaland-app/src/styles/_config.scss
@@ -261,6 +261,11 @@ text {
 
       span {
         color: $dark-blue;
+
+        &.locationLabel {
+          color: $dust-blue;
+          font-weight: bold;
+        }
       }
     }
 
@@ -325,6 +330,10 @@ text {
 
       span {
         color: $dark-blue;
+        &.locationLabel {
+          color: $dust-blue;
+          font-weight: bold;
+        }
       }
     }
   }


### PR DESCRIPTION
- location name is bold now
- location name is in darker blue now (the other one was a bit too loud I felt)
- years in the captionare now in the color of the default text to make it consistent.

#337 